### PR TITLE
Fix IndexError: list index out of range caused by uknown categories

### DIFF
--- a/HTB-University-Completion-Tracker.py
+++ b/HTB-University-Completion-Tracker.py
@@ -305,6 +305,10 @@ class HTB_Univ_Fetcher():
 		ENDPOINT = "https://www.hackthebox.com/api/v4/challenge/list"
 		fetch_res = self.__do_get(ENDPOINT)
 		for challenge in fetch_res["challenges"]:
+			# Debug: print category ID if it's unexpected
+			cat_id = challenge["challenge_category_id"]
+			if cat_id < 1 or cat_id > 22:
+				print(f"Warning: Unexpected category ID {cat_id} for challenge {challenge['name']}")
 			HTB_Challenge(challenge['id'],challenge["name"],False,challenge["difficulty"], categorie=challenge["challenge_category_id"])
 		"""
 		List Retired Challenges
@@ -312,6 +316,10 @@ class HTB_Univ_Fetcher():
 		ENDPOINT = "https://www.hackthebox.com/api/v4/challenge/list/retired"
 		fetch_res = self.__do_get(ENDPOINT)
 		for challenge in fetch_res["challenges"]:
+			# Debug: print category ID if it's unexpected
+			cat_id = challenge["challenge_category_id"]
+			if cat_id < 1 or cat_id > 22:
+				print(f"Warning: Unexpected category ID {cat_id} for challenge {challenge['name']}")
 			HTB_Challenge(challenge['id'],challenge["name"],True,challenge["difficulty"], categorie=challenge["challenge_category_id"])
 
 	def fetch_all_machines(self):
@@ -425,3 +433,4 @@ if __name__ == "__main__":
 		if not f.is_flagged():
 			print(f"{f.id} -- {f.name}")
 	print()
+

--- a/HTB-University-Completion-Tracker.py
+++ b/HTB-University-Completion-Tracker.py
@@ -149,8 +149,11 @@ class HTB_Challenge(_HTB_BaseObject):
 		if str_categorie==None:
 			if not isinstance(categorie,int):
 				raise Error("Categorie should be an integer of the categorie id")
-			categories = ["Reverse","Crypto","","Pwn","Web","Misc","Forensic","Mobile","","Hardware","GamePwn","Blockchain","","","","","","","","","AI-ML", "Coding"]
-			self.categorie = categories[categorie-1]
+			categories = ["Reverse","Crypto","","Pwn","Web","Misc","Forensic","Mobile","","Hardware","GamePwn","Blockchain","","","","","","","","","AI-ML", "Coding", "ICS"]
+			if categorie < 1 or categorie > len(categories):
+				self.categorie = "Unknown"
+			else:
+				self.categorie = categories[categorie-1]
 		else:
 			self.categorie = str_categorie
 		CHALLENGES.append(self)


### PR DESCRIPTION
Actuellement quand on lance le script on a cette sortie : 
```sh
https://www.hackthebox.com/api/v4/challenge/list
Traceback (most recent call last):
  File "/HTB-University-Completion-Tracker/HTB-University-Completion-Tracker.py", line 385, in <module>
    fetcher.fetch_all_challenges()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "HTB-University-Completion-Tracker/HTB-University-Completion-Tracker.py", line 305, in fetch_all_challenges
    HTB_Challenge(challenge['id'],challenge["name"],False,challenge["difficulty"], categorie=challenge["challenge_category_id"])
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/GCC-Team/HTB-University-Completion-Tracker/HTB-University-Completion-Tracker.py", line 153, in __init__
    self.categorie = categories[categorie-1]
                     ~~~~~~~~~~^^^^^^^^^^^^^
IndexError: list index out of range
```

Cette erreur est causé par l'ajout de la nouvelle catégorie de challenges **ICS** sur HTB, cette catégorie n'a pas encore été référencé dans l'api donc on a une erreur. 

J'ai corrigé l'erreur en ignorant les catégories inconnues, ce qui évite les problèmes si de nouvelles catégories non référencées dans l’API apparaissent. J’ai également ajouté "ICS" à la liste des catégories, afin que les nouveaux challenges soient correctement catégorisés dès qu’elle sera prise en charge.
